### PR TITLE
Add FileType for load autocmd FileType settings.

### DIFF
--- a/unbundle.vim
+++ b/unbundle.vim
@@ -31,10 +31,26 @@ function! Unftbundle(type)
       execute 'source' fnameescape(l:plugin)
     endfor
 
+    " reload autocmd FileType when filetype already loaded
+    if s:filetype_loaded == 1
+      let &l:filetype = &l:filetype
+    endif
+
     " apply newly loaded ftbundles to currently open buffers
-    doautoall BufRead,FileType
+    doautoall BufRead
   endif
 endfunction
+
+" If `filetype plugin indent on` already set before unbundle.vim load
+" unbundle.vim need to reload filetype
+redir => filetype_out
+  silent! filetype
+redir END
+
+let s:filetype_loaded = 0
+if filetype_out =~# 'plugin:ON\|plugin:(on)'
+  let s:filetype_loaded = 1
+endif
 
 " commands for manual invocation
 command! Unbundle call Unbundle('bundle/*')

--- a/unbundle.vim
+++ b/unbundle.vim
@@ -32,7 +32,7 @@ function! Unftbundle(type)
     endfor
 
     " apply newly loaded ftbundles to currently open buffers
-    doautoall BufRead
+    doautoall BufRead,FileType
   endif
 endfunction
 


### PR DESCRIPTION
Hi, nice plugin I like it. But I've got a problem.

I use [jedi.vim](https://github.com/davidhalter/jedi-vim) which is auto complete for Python.
I've Downloaded `jedi.vim` to `~/.vim/ftbundle/python/` and then open python file.
But `jedi.vim` did not work at GUI MacVim.app.
(CUI MacVim works well)

unbundle.vim did not load `autocmd FileType` when ftbundle plugin loaded.

`jedi.vim` defined `autocmd FileType python` at  https://github.com/davidhalter/jedi-vim/blob/master/plugin/jedi.vim#L49
(One of the example using `autocmd FileType`)

IMHO unbundle.vim is heavily related with filetype. A lot of FileType plugin defined `autocmd FileType`.

So, I add `FileType` to `doautoall`.

Please check and include.

Regards,
